### PR TITLE
Update 2021.md

### DIFF
--- a/content/schedule/2021.md
+++ b/content/schedule/2021.md
@@ -19,10 +19,11 @@ Description: Field Days Schedule of Events for 2021
 | July 2 & 3 | Green Mountain Barrel Racing (Contact: Bill Superneau 782-9964)
 | July 8-11 | VT State 4-H Horse Show (Contact: Wendy Sorrell 656-5418)PENDING* 
 | July 17 | Bonnie Roleau Memorial
-| July 25 | Addison Flaming Manes Horse Show (Contact: Kathy Kennett 759-2015)
+| July 24 | Addison Flaming Manes Horse Show (Contact: Kathy Kennett 759-2015)
 | July 31-Aug 1 | Champlain Valley Horse Show (Contact Shelly Edson 802-363-1997)
 | August 9-12 | Addison Cty Fair & Field Days 4-H Horse & Pony Show & Open Shows 
 | August 10-14 | 73rd Addison Cty Fair & Field Days (Contact: Cara Mullin 545-2557)
+| August 13-14 | Addison Cty Fair & Field Days Draft Horse Show (Contact: Kathy Kennett 759-2015)
 | August 22 | VT Quarter Horse Gymkhana (Contact: Lori Brown (802) 989-9186)
 | August 27-28 | Green Mountain Barrel Racing (Contact: Bill Superneau 782-9964)
 | Sept. 18-19 | VTPA Benefit Tractor Pull (Contact: Jason VanDeWeert)


### PR DESCRIPTION
Correcting the date for the Addison Flaming Manes horse show (July 24th, not the 25th), and putting the dates of the Draft Horse show explicitly in the schedule as many of those exhibitors would likely not find it.